### PR TITLE
Remove unnecessary lines for ignoring mac files

### DIFF
--- a/templates/cybele_gitignore
+++ b/templates/cybele_gitignore
@@ -25,7 +25,6 @@ vendor/bundler_gems
 
 # Ignore ide and text editor
 .idea
-.idea/**/*
 
 # Ignore pow files
 .powrc


### PR DESCRIPTION
`*.DS_Store` and `**/.DS_Store` are not necessary to ignore mac filesystem dusts. `.DS_Store` line is already enough to complete this task.
