### PR TITLE
Update Gemfile for ransack

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -12,7 +12,7 @@ gem 'config', '~> 1.7'
 gem 'rollbar', '~> 2.16', '>= 2.16.2'
 
 # Ransack is the successor to the MetaSearch gem.
-gem 'ransack', '~> 1.8', '>= 1.8.4'
+gem 'ransack', '~> 2.1'
 
 # will_paginate
 gem 'will_paginate', '~> 3.1', '>= 3.1.6'


### PR DESCRIPTION
When the application is installed, it tries to access the admin and user path in the hq area and it gives the error "wrong number of arguments (given 4, expected 3)". The error is resolved when the gem is updated.